### PR TITLE
warning message when E-stage diameter is set smaller than DE-stage one.

### DIFF
--- a/src/DetectorConstruction.cc
+++ b/src/DetectorConstruction.cc
@@ -918,7 +918,10 @@ void DetectorConstruction::ConstructTelescopeDetector()		// stub, will be writte
 	// check if the diameter of the E-stage is bigger than the DE diameter and set it to the DE double if not.
 	if( secondStageSizeDim <= detectorSizeWidth )
 	{
+		G4cout << "WARNING: the telescope E-stage diameter set (" << secondStageSizeDim << ") is smaller than the DE-stage diameter (" << detectorSizeWidth << ").";
+		G4cout << "To be compliant with the telescope structure, it has to be at least the same dimension.";
 		secondStageSizeDim = 2*detectorSizeWidth;
+		G4cout << "E-stage diameter set to default as double the DE-stage diameter: " << secondStageSizeDim << ".";
 	}
 
 	// DE intrinsic-diamond crystal

--- a/src/SensitiveDetector.cc
+++ b/src/SensitiveDetector.cc
@@ -97,15 +97,10 @@ G4bool SensitiveDetector::ProcessHits(G4Step* aStep,
 	
 	// only consider ions, protons, and neutrons for path length
 	G4String particleName = aStep -> GetTrack() -> GetParticleDefinition() -> GetParticleName();
+	G4int particleZ = aStep -> GetTrack() -> GetParticleDefinition() -> GetAtomicNumber();
 	
-	if ( (particleName != "proton") &&
-			(particleName != "neutron") &&
-			(particleName != "alpha") &&
-			(particleName != "deuton") && 
-			(particleName != "triton") && 
-			(particleName != "He3") && 
-			(particleName !="GenericIon") )
-				len = 0.;	
+	if ( (particleZ < 1) && (particleName != "neutron"))
+		len = 0.;
 
 	newHit->SetPath(len);
 	


### PR DESCRIPTION
As suggested, added a warning message when the E-stage diameter is set smaller than the DE-stage diameter, informing it is set to default as double the DE-stage diameter.